### PR TITLE
Add ignoreFiles property to command configuration

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,7 @@ export const DEFAULT_CONFIG: Config = {
       command: "cspell",
       args: ["--no-progress", "--no-summary"],
       behavior: "warn",
+      ignoreFiles: ["composer.lock", "package-lock.json"],
       priority: 8,
     },
     ESLINT: {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -7,6 +7,7 @@ export type Command = {
   args?: string[];
   files?: string[];
   includeFiles?: boolean;
+  ignoreFiles?: string[];
   priority?: number;
 };
 

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -122,11 +122,15 @@ export function getToolsByExtension(files: string[], config: Config, ext: string
     Object.entries(toolsToLint)
       .filter(([tool]) => TOOLS[tool])
       .map(([tool, fileList]) => {
+        const filteredFiles = fileList.filter((file) => !TOOLS[tool].ignoreFiles?.includes(file));
+        // If no files are found after filtering, add "." as a placeholder
+        // This ensures the tool can still run without failing due to missing files
+        if (filteredFiles.length === 0) filteredFiles.push(".");
         return [
           tool,
           {
             ...TOOLS[tool],
-            files: TOOLS[tool].includeFiles === false ? [] : fileList,
+            files: TOOLS[tool].includeFiles === false ? [] : filteredFiles,
           },
         ];
       }),


### PR DESCRIPTION
Introduce an `ignoreFiles` property to the command configuration, allowing specific files to be excluded from processing. Update the relevant functions to utilize this new property effectively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option to exclude specific dependency lock files from file scanning.
  - Enhanced file processing to filter out unwanted files and apply default handling when no valid files remain. 
  - Added flexibility to command definitions by allowing the specification of files to be ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->